### PR TITLE
Add shell+awk parallel queue script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # oparal
-shell for parallel queue
+
+This repository contains a simple parallel queue implementation using a shell script and AWK.
+
+## Script
+
+`parallel_queue.sh` reads a list of shell commands from a file and executes them in parallel using a specified level of concurrency. AWK is used to feed the commands into a FIFO queue that multiple worker processes consume.
+
+### Usage
+
+```bash
+./parallel_queue.sh [-n concurrency] tasks_file
+```
+
+- `concurrency`: Number of worker processes (defaults to 2).
+- `tasks_file`: A text file where each line is a command to run.
+
+### Example
+
+Create a file `tasks.txt` with commands:
+
+```bash
+sleep 1 && echo one
+sleep 2 && echo two
+sleep 3 && echo three
+```
+
+Run the queue with two workers:
+
+```bash
+./parallel_queue.sh -n 2 tasks.txt
+```
+
+The script will print which worker runs each command and execute them concurrently.

--- a/parallel_queue.sh
+++ b/parallel_queue.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# parallel_queue.sh - simple parallel queue using shell and awk
+# Usage: parallel_queue.sh [-n concurrency] tasks_file
+
+set -e
+
+concurrency=2
+usage() {
+  echo "Usage: $0 [-n concurrency] tasks_file" >&2
+  exit 1
+}
+
+while getopts "n:" opt; do
+  case "$opt" in
+    n) concurrency="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+shift $((OPTIND-1))
+
+[ $# -eq 1 ] || usage
+
+tasks_file="$1"
+
+[ -f "$tasks_file" ] || { echo "Task file $tasks_file not found" >&2; exit 1; }
+
+pipe=$(mktemp -u)
+mkfifo "$pipe"
+
+# Launch producer with AWK
+awk '{print}' "$tasks_file" > "$pipe" &
+producer_pid=$!
+
+# Launch workers
+for i in $(seq "$concurrency"); do
+  (
+    while IFS= read -r cmd; do
+      echo "[worker $i] $cmd"
+      eval "$cmd"
+    done < "$pipe"
+  ) &
+  pids="$pids $!"
+done
+
+wait "$producer_pid"
+
+# Close the pipe for writing to signal EOF to workers
+exec 3>"$pipe"
+exec 3>&-
+
+wait $pids
+rm "$pipe"


### PR DESCRIPTION
## Summary
- implement `parallel_queue.sh` for running queued tasks in parallel using shell and AWK
- document how to use the script in README

## Testing
- `./parallel_queue.sh -n 2 tasks.txt`

------
https://chatgpt.com/codex/tasks/task_e_684059e8f6c0832fa6bb1d62e06fecc8