### PR TITLE
Handle noninteractive runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Options:
 - `-us USER` SQL*Plus username (default: `system`).
 - `-pa PASS` SQL*Plus password (default: `manager`).
 - `-id ID`  Custom instance identifier. When omitted, a unique ID is auto-generated.
-- `-isolation MODE` Isolation mode: `workdir` keeps runs from different working
-  directories separate, while `global` coordinates all runs system-wide.
 - `-h`     Show help.
 
 The script scans every directory from `a` to `z` under the specified root. Files must be named like `00001-something-sh-N` or `00002-title-sql-N`. Shell files are run with `sh` while SQL files are executed via `sqlplus USER/PASS @file`. Files are processed in numeric order and after completion the trailing `N` is changed to `Y`.

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Options:
 
 The script scans every directory from `a` to `z` under the specified root. Files must be named like `00001-something-sh-N` or `00002-title-sql-N`. Shell files are run with `sh` while SQL files are executed via `sqlplus USER/PASS @file`. Files are processed in numeric order and after completion the trailing `N` is changed to `Y`.
 
-During execution a progress line appears every 10 seconds showing completed percentage, the number of running slave processes and how many have been forked in total, along with current CPU, memory, disk and network statistics. When finished a results file named `YYYYMMDD_HHMM.result.csv` is written containing start time, end time and duration for each file.
+During execution a progress line appears every 10 seconds showing completed percentage, the number of running slave processes and how many have been forked in total, along with current CPU, memory, disk and network statistics. When finished a results file named `YYYYMMDD_HHMM_PID.result.csv` is written containing start time, end time and duration for each file. The PID ensures multiple runs from different directories do not clobber one another.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Options:
 - `-d DIR` Root directory containing `a`..`z` subdirectories (default: `./`).
 - `-i MODE` Interactive mode. `Y` asks before processing each directory, `A` runs all directories without prompts (default: `Y`). When standard input is not a terminal (for example when running with `nohup`), mode automatically becomes `A`.
 - `-p NN`  Maximum concurrent processes (default: 200).
+- `-op NN` Number of slave processes to run in parallel. Use `1` for serial execution.
 - `-us USER` SQL*Plus username (default: `system`).
 - `-pa PASS` SQL*Plus password (default: `manager`).
 - `-id ID`  Custom instance identifier. When omitted, a unique ID is auto-generated.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # oparal
-shell for parallel queue
+
+This project provides a Bash script for running shell or SQL files found under alphabetical subdirectories. Files are executed in numeric order and more jobs are started while CPU and memory usage remain below configured thresholds.
+
+## Usage
+
+```
+./oparal.sh [options]
+```
+
+Options:
+
+- `-c NN`  CPU usage threshold percentage. New tasks start while usage is below this value (default: 85).
+- `-m NN`  Memory usage threshold percentage. New tasks start while usage is below this value (default: 80).
+- `-d DIR` Root directory containing `a`..`z` subdirectories (default: `./`).
+- `-i MODE` Interactive mode. `Y` asks before processing each directory, `A` runs all directories without prompts (default: `Y`). When standard input is not a terminal (for example when running with `nohup`), mode automatically becomes `A`.
+- `-p NN`  Maximum concurrent processes (default: 200).
+- `-us USER` SQL*Plus username (default: `system`).
+- `-pa PASS` SQL*Plus password (default: `manager`).
+- `-h`     Show help.
+
+The script scans every directory from `a` to `z` under the specified root. Files must be named like `00001-something-sh-N` or `00002-title-sql-N`. Shell files are run with `sh` while SQL files are executed via `sqlplus USER/PASS @file`. Files are processed in numeric order and after completion the trailing `N` is changed to `Y`.
+
+During execution a progress line appears every 10 seconds showing completed percentage along with current CPU, memory, disk and network statistics. When finished a results file named `YYYYMMDD_HHMM.result.csv` is written containing start time, end time and duration for each file.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Options:
 - `-p NN`  Maximum concurrent processes (default: 200).
 - `-us USER` SQL*Plus username (default: `system`).
 - `-pa PASS` SQL*Plus password (default: `manager`).
+- `-id ID`  Custom instance identifier. When omitted, a unique ID is auto-generated.
+- `-isolation MODE` Isolation mode: `workdir` keeps runs from different working
+  directories separate, while `global` coordinates all runs system-wide.
 - `-h`     Show help.
 
 The script scans every directory from `a` to `z` under the specified root. Files must be named like `00001-something-sh-N` or `00002-title-sql-N`. Shell files are run with `sh` while SQL files are executed via `sqlplus USER/PASS @file`. Files are processed in numeric order and after completion the trailing `N` is changed to `Y`.
 
-During execution a progress line appears every 10 seconds showing completed percentage, the number of running slave processes and how many have been forked in total, along with current CPU, memory, disk and network statistics. When finished a results file named `YYYYMMDD_HHMM_PID.result.csv` is written containing start time, end time and duration for each file. The PID ensures multiple runs from different directories do not clobber one another.
+During execution a progress line appears every 10 seconds showing completed percentage, the number of running slave processes and how many have been forked in total, along with current CPU, memory, disk and network statistics. When finished a results file named `YYYYMMDD_HHMM_INSTANCE.result.csv` is written, containing start time, end time and duration for each file. The instance identifier keeps results from concurrent runs separate.

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Options:
 
 The script scans every directory from `a` to `z` under the specified root. Files must be named like `00001-something-sh-N` or `00002-title-sql-N`. Shell files are run with `sh` while SQL files are executed via `sqlplus USER/PASS @file`. Files are processed in numeric order and after completion the trailing `N` is changed to `Y`.
 
-During execution a progress line appears every 10 seconds showing completed percentage along with current CPU, memory, disk and network statistics. When finished a results file named `YYYYMMDD_HHMM.result.csv` is written containing start time, end time and duration for each file.
+During execution a progress line appears every 10 seconds showing completed percentage, the number of running slave processes and how many have been forked in total, along with current CPU, memory, disk and network statistics. When finished a results file named `YYYYMMDD_HHMM.result.csv` is written containing start time, end time and duration for each file.

--- a/oparal.sh
+++ b/oparal.sh
@@ -29,12 +29,7 @@ Usage: $0 [options]
   -us USER  sqlplus username (default system)
   -pa PASS  sqlplus password (default manager)
   -id INSTANCE_ID  unique instance identifier (auto-generated)
-  -isolation MODE  isolation mode (workdir/global) (default workdir)
   -h  show this help
-
-Isolation modes:
-  workdir - Each working directory is completely isolated
-  global  - All instances share locks regardless of working directory
 USAGE
 }
 
@@ -47,7 +42,6 @@ max_processes=200
 sql_user="system"
 sql_pass="manager"
 custom_instance_id=""
-isolation_mode="workdir"
 
 # Parse arguments
 while [ $# -gt 0 ]; do
@@ -60,17 +54,11 @@ while [ $# -gt 0 ]; do
     -us) sql_user=$2; shift 2;;
     -pa) sql_pass=$2; shift 2;;
     -id) custom_instance_id=$2; shift 2;;
-    -isolation) isolation_mode=$2; shift 2;;
     -h) usage; exit 0;;
     *) usage; exit 1;;
   esac
 done
 
-# Validate isolation mode
-if [ "$isolation_mode" != "workdir" ] && [ "$isolation_mode" != "global" ]; then
-    echo "Error: Invalid isolation mode. Use 'workdir' or 'global'" >&2
-    exit 1
-fi
 
 # Use custom instance ID if provided
 if [ -n "$custom_instance_id" ]; then
@@ -79,17 +67,10 @@ else
     readonly FINAL_INSTANCE_ID="$INSTANCE_ID"
 fi
 
-# Adjust paths based on isolation mode
-if [ "$isolation_mode" = "global" ]; then
-    readonly FINAL_LOCK_DIR="/tmp/.parallel_locks_global"
-    readonly FINAL_LOG_DIR="${WORK_DIR}/.parallel_logs"
-    readonly FINAL_GLOBAL_LOCK="/tmp/.parallel_locks_global/global.lock"
-    mkdir -p "$FINAL_LOCK_DIR"
-else
-    readonly FINAL_LOCK_DIR="$LOCK_DIR"
-    readonly FINAL_LOG_DIR="$LOG_DIR"
-    readonly FINAL_GLOBAL_LOCK="$GLOBAL_LOCK"
-fi
+# Paths for this working directory
+readonly FINAL_LOCK_DIR="$LOCK_DIR"
+readonly FINAL_LOG_DIR="$LOG_DIR"
+readonly FINAL_GLOBAL_LOCK="$GLOBAL_LOCK"
 
 # Instance-specific files
 readonly results="${FINAL_LOG_DIR}/$(date +%Y%m%d_%H%M)_${FINAL_INSTANCE_ID}.result.csv"
@@ -105,7 +86,6 @@ echo $$ > "$final_pid_file"
 check_running_instances() {
     local count=0
     echo "=== Running Instances ==="
-    echo "Isolation mode: $isolation_mode"
     echo "Work directory: $WORK_DIR"
     echo "Lock directory: $FINAL_LOCK_DIR"
     echo "Checking pattern: ${FINAL_LOCK_DIR}/${SCRIPT_NAME}.*.pid"
@@ -166,21 +146,6 @@ unmark_file_processing() {
     rm -f "$file_lock"
 }
 
-get_total_script_processes() {
-    local total=0
-    for pid_file in "${FINAL_LOCK_DIR}"/${SCRIPT_NAME}.*.pid; do
-        [ -f "$pid_file" ] || continue
-        local pid
-        pid=$(cat "$pid_file" 2>/dev/null || echo "")
-        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-            local children
-            children=$(pgrep -P "$pid" 2>/dev/null | wc -l)
-            total=$((total + children))
-        fi
-    done
-    echo "$total"
-}
-
 get_workdir_script_processes() {
     local total=0
     for pid_file in "${FINAL_LOCK_DIR}"/${SCRIPT_NAME}.*.pid; do
@@ -211,7 +176,6 @@ get_mem_usage() {
 progress_monitor() {
     echo "Starting progress monitor for instance: $FINAL_INSTANCE_ID"
     echo "Work directory: $WORK_DIR"
-    echo "Isolation mode: $isolation_mode"
     local total
     total=$(find "$root_dir" -maxdepth 2 -type f \( -name '*-sh-N' -o -name '*-sql-N' \) 2>/dev/null | wc -l)
     while true; do
@@ -224,19 +188,11 @@ progress_monitor() {
         mem=$(get_mem_usage)
         running=$(jobs -r 2>/dev/null | wc -l)
         running=$(( running > 0 ? running-1 : 0 ))
-        if [ "$isolation_mode" = "workdir" ]; then
-            workdir_procs=$(get_workdir_script_processes)
-            printf "[%s] Progress: %d/%d (%d%%) CPU:%d%% MEM:%d%% Local:%d WorkDir:%d ERR:%d\n" \
-                   "$FINAL_INSTANCE_ID" "$completed" "$total" \
-                   "$([ "$total" -gt 0 ] && echo $(( completed * 100 / total )) || echo "100")" \
-                   "$cpu" "$mem" "$running" "$workdir_procs" "$errors"
-        else
-            total_procs=$(get_total_script_processes)
-            printf "[%s] Progress: %d/%d (%d%%) CPU:%d%% MEM:%d%% Local:%d Global:%d ERR:%d\n" \
-                   "$FINAL_INSTANCE_ID" "$completed" "$total" \
-                   "$([ "$total" -gt 0 ] && echo $(( completed * 100 / total )) || echo "100")" \
-                   "$cpu" "$mem" "$running" "$total_procs" "$errors"
-        fi
+        workdir_procs=$(get_workdir_script_processes)
+        printf "[%s] Progress: %d/%d (%d%%) CPU:%d%% MEM:%d%% Local:%d WorkDir:%d ERR:%d\n" \
+               "$FINAL_INSTANCE_ID" "$completed" "$total" \
+               "$([ "$total" -gt 0 ] && echo $(( completed * 100 / total )) || echo "100")" \
+               "$cpu" "$mem" "$running" "$workdir_procs" "$errors"
     done
 }
 
@@ -306,7 +262,6 @@ cleanup() {
         fi
         printf '\n=== INSTANCE %s SUMMARY ===\n' "$FINAL_INSTANCE_ID"
         printf 'Work directory: %s\n' "$WORK_DIR"
-        printf 'Isolation mode: %s\n' "$isolation_mode"
         printf 'Total completed: %d\n' "$total_completed"
         printf 'Total errors: %d\n' "$total_errors"
         printf 'Results: %s\n' "$results"
@@ -392,11 +347,7 @@ for dir in $(find "$root_dir" -maxdepth 1 -type d -regex '.*/[a-z]' | sort); do
             mem=$(get_mem_usage)
             running=$(jobs -r 2>/dev/null | wc -l)
             running=$(( running > 0 ? running-1 : 0 ))
-            if [ "$isolation_mode" = "workdir" ]; then
-                limit_procs=$(get_workdir_script_processes)
-            else
-                limit_procs=$(get_total_script_processes)
-            fi
+            limit_procs=$(get_workdir_script_processes)
             if [ "$cpu" -lt "$cpu_threshold" ] && \
                [ "$mem" -lt "$mem_threshold" ] && \
                [ "$running" -lt "$max_processes" ] && \

--- a/oparal.sh
+++ b/oparal.sh
@@ -27,6 +27,7 @@ Usage: $0 [options]
   -i  interactive mode (Y ask each dir, A process all without asking)
   -p  maximum concurrent processes (default 200)
   -us USER  sqlplus username (default system)
+  -pa PASS  sqlplus password (default manager)
   -id INSTANCE_ID  unique instance identifier (auto-generated)
   -isolation MODE  isolation mode (workdir/global) (default workdir)
   -h  show this help
@@ -38,25 +39,26 @@ USAGE
 }
 
 # Default values
-cpu_limit=85
-mem_limit=80
-root="./"
-interactive="Y"
-max_proc=200
+cpu_threshold=85
+mem_threshold=80
+root_dir="./"
+interactive_mode="Y"
+max_processes=200
 sql_user="system"
-sql_pass=""
+sql_pass="manager"
 custom_instance_id=""
 isolation_mode="workdir"
 
 # Parse arguments
 while [ $# -gt 0 ]; do
   case "$1" in
-    -c) cpu_limit=$2; shift 2;;
-    -m) mem_limit=$2; shift 2;;
-    -d) root=$2; shift 2;;
-    -i) interactive=$2; shift 2;;
-    -p) max_proc=$2; shift 2;;
+    -c) cpu_threshold=$2; shift 2;;
+    -m) mem_threshold=$2; shift 2;;
+    -d) root_dir=$2; shift 2;;
+    -i) interactive_mode=$2; shift 2;;
+    -p) max_processes=$2; shift 2;;
     -us) sql_user=$2; shift 2;;
+    -pa) sql_pass=$2; shift 2;;
     -id) custom_instance_id=$2; shift 2;;
     -isolation) isolation_mode=$2; shift 2;;
     -h) usage; exit 0;;
@@ -211,7 +213,7 @@ progress_monitor() {
     echo "Work directory: $WORK_DIR"
     echo "Isolation mode: $isolation_mode"
     local total
-    total=$(find "$root" -maxdepth 2 -type f \( -name '*-sh-N' -o -name '*-sql-N' \) 2>/dev/null | wc -l)
+    total=$(find "$root_dir" -maxdepth 2 -type f \( -name '*-sh-N' -o -name '*-sql-N' \) 2>/dev/null | wc -l)
     while true; do
         sleep 10
         local completed forked errors cpu mem running workdir_procs total_procs
@@ -311,25 +313,28 @@ cleanup() {
 }
 
 validate_inputs() {
-    if [[ ! "$cpu_limit" =~ ^[0-9]+$ ]] || [ "$cpu_limit" -lt 1 ] || [ "$cpu_limit" -gt 100 ]; then
+    if [[ ! "$cpu_threshold" =~ ^[0-9]+$ ]] || [ "$cpu_threshold" -lt 1 ] || [ "$cpu_threshold" -gt 100 ]; then
         echo "Error: CPU limit must be 1-100" >&2
         exit 1
     fi
-    if [[ ! "$mem_limit" =~ ^[0-9]+$ ]] || [ "$mem_limit" -lt 1 ] || [ "$mem_limit" -gt 100 ]; then
+    if [[ ! "$mem_threshold" =~ ^[0-9]+$ ]] || [ "$mem_threshold" -lt 1 ] || [ "$mem_threshold" -gt 100 ]; then
         echo "Error: Memory limit must be 1-100" >&2
         exit 1
     fi
-    if [ ! -d "$root" ]; then
-        echo "Error: Directory '$root' does not exist" >&2
+    if [ ! -d "$root_dir" ]; then
+        echo "Error: Directory '$root_dir' does not exist" >&2
         exit 1
     fi
-    if [[ ! "$max_proc" =~ ^[0-9]+$ ]] || [ "$max_proc" -lt 1 ]; then
+    if [[ ! "$max_processes" =~ ^[0-9]+$ ]] || [ "$max_processes" -lt 1 ]; then
         echo "Error: Max processes must be a positive integer" >&2
         exit 1
     fi
 }
 
 get_password() {
+    if [ -n "$sql_pass" ]; then
+        return
+    fi
     if [ -n "${SQL_PASSWORD:-}" ]; then
         sql_pass="$SQL_PASSWORD"
     elif [ -f "${HOME}/.sqlpass" ]; then
@@ -353,8 +358,8 @@ echo "0" > "$started_file"
 echo "0" > "$error_file"
 echo "directory,file,start,end,duration,status,instance,workdir" > "$results"
 
-if [ ! -t 0 ] && [ "$interactive" = "Y" ]; then
-    interactive="A"
+if [ ! -t 0 ] && [ "$interactive_mode" = "Y" ]; then
+    interactive_mode="A"
 fi
 
 trap cleanup EXIT INT TERM
@@ -364,13 +369,13 @@ check_running_instances
 progress_monitor &
 mon_pid=$!
 
-for dir in $(find "$root" -maxdepth 1 -type d -regex '.*/[a-z]' | sort); do
-    if [ "$interactive" = "Y" ]; then
+for dir in $(find "$root_dir" -maxdepth 1 -type d -regex '.*/[a-z]' | sort); do
+    if [ "$interactive_mode" = "Y" ]; then
         read -p "Process directory $(basename "$dir")? [Y/N/A] " ans
         case $ans in
             Y|y) ;;
             N|n) continue ;;
-            A|a) interactive="A" ;;
+            A|a) interactive_mode="A" ;;
             *) continue ;;
         esac
     fi
@@ -391,10 +396,10 @@ for dir in $(find "$root" -maxdepth 1 -type d -regex '.*/[a-z]' | sort); do
             else
                 limit_procs=$(get_total_script_processes)
             fi
-            if [ "$cpu" -lt "$cpu_limit" ] && \
-               [ "$mem" -lt "$mem_limit" ] && \
-               [ "$running" -lt "$max_proc" ] && \
-               [ "$limit_procs" -lt $((max_proc * 2)) ]; then
+            if [ "$cpu" -lt "$cpu_threshold" ] && \
+               [ "$mem" -lt "$mem_threshold" ] && \
+               [ "$running" -lt "$max_processes" ] && \
+               [ "$limit_procs" -lt $((max_processes * 2)) ]; then
                 break
             fi
             sleep 1

--- a/oparal.sh
+++ b/oparal.sh
@@ -124,7 +124,7 @@ check_running_instances() {
     done
     echo "Total active instances: $count"
     echo "========================="
-    return $count
+    return 0
 }
 
 is_file_being_processed() {
@@ -301,7 +301,9 @@ cleanup() {
         local total_completed total_errors
         total_completed=$(wc -l < "$results" 2>/dev/null || echo "1")
         total_completed=$((total_completed - 1))
-        total_errors=$(grep -c "FAILED" "$results" 2>/dev/null || echo "0")
+        if ! total_errors=$(grep -c "FAILED" "$results" 2>/dev/null); then
+            total_errors=0
+        fi
         printf '\n=== INSTANCE %s SUMMARY ===\n' "$FINAL_INSTANCE_ID"
         printf 'Work directory: %s\n' "$WORK_DIR"
         printf 'Isolation mode: %s\n' "$isolation_mode"
@@ -386,7 +388,6 @@ for dir in $(find "$root_dir" -maxdepth 1 -type d -regex '.*/[a-z]' | sort); do
             continue
         fi
         while true; do
-            local cpu mem running limit_procs
             cpu=$(get_cpu_usage)
             mem=$(get_mem_usage)
             running=$(jobs -r 2>/dev/null | wc -l)
@@ -404,7 +405,6 @@ for dir in $(find "$root_dir" -maxdepth 1 -type d -regex '.*/[a-z]' | sort); do
             fi
             sleep 1
         done
-        local started
         started=$(cat "$started_file" 2>/dev/null || echo "0")
         echo $((started + 1)) > "$started_file"
         execute_file "$f" &

--- a/oparal.sh
+++ b/oparal.sh
@@ -48,7 +48,7 @@ completed=0
 started=0
 progress_file=$(mktemp)
 started_file=$(mktemp)
-results="$(date +%Y%m%d_%H%M).result.csv"
+results="$(date +%Y%m%d_%H%M)_$$.result.csv"
 
 echo "0" > "$progress_file"
 echo "0" > "$started_file"

--- a/oparal.sh
+++ b/oparal.sh
@@ -45,10 +45,13 @@ fi
 
 # internal counters
 completed=0
+started=0
 progress_file=$(mktemp)
+started_file=$(mktemp)
 results="$(date +%Y%m%d_%H%M).result.csv"
 
 echo "0" > "$progress_file"
+echo "0" > "$started_file"
 echo "directory,file,start,end,duration" > "$results"
 
 get_cpu_usage() {
@@ -73,6 +76,7 @@ progress_monitor() {
   while true; do
     sleep 10
     completed=$(cat "$progress_file")
+    forked=$(cat "$started_file")
     cpu=$(get_cpu_usage)
     mem=$(get_mem_usage)
     disk=$(get_disk_usage)
@@ -87,7 +91,7 @@ progress_monitor() {
     else
       progress=100
     fi
-    echo "Progress: $completed/$total (${progress}%) CPU:${cpu}% MEM:${mem}% DISK:${disk} NET:${rx}/${tx} RUN:${running}"
+    echo "Progress: $completed/$total (${progress}%) CPU:${cpu}% MEM:${mem}% DISK:${disk} NET:${rx}/${tx} RUN:${running} FORK:${forked}"
   done
 }
 
@@ -117,7 +121,7 @@ cleanup() {
   kill $mon_pid 2>/dev/null
   kill $(jobs -p) 2>/dev/null
   wait $mon_pid 2>/dev/null
-  rm -f "$progress_file"
+  rm -f "$progress_file" "$started_file"
 }
 
 trap cleanup EXIT INT TERM
@@ -147,6 +151,8 @@ for dir in $(find "$root" -maxdepth 1 -type d -regex '.*/[a-z]' | sort); do
       fi
       sleep 1
     done
+    started=$((started+1))
+    echo "$started" > "$started_file"
     execute_file "$f" &
   done
   wait

--- a/oparal.sh
+++ b/oparal.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
-# Execute shell and SQL files in alphabetical directories with simple CPU/memory
-# based parallelism. Only bash and awk are used.
+# Work directory isolated parallel execution script
+
+set -euo pipefail
+
+readonly SCRIPT_NAME="$(basename "$0")"
+readonly WORK_DIR="$(pwd)"  # current working directory
+readonly INSTANCE_ID="${USER:-$(id -un)}_$(hostname)_$$_$(date +%s%N)"
+
+# Per-work-directory paths
+readonly LOCK_DIR="${WORK_DIR}/.parallel_locks"
+readonly LOG_DIR="${WORK_DIR}/.parallel_logs"
+readonly PID_FILE="${LOCK_DIR}/${SCRIPT_NAME}.${INSTANCE_ID}.pid"
+
+# Global lock per working directory
+readonly GLOBAL_LOCK="${LOCK_DIR}/global.lock"
+
+# Create necessary directories in current work directory
+mkdir -p "$LOCK_DIR" "$LOG_DIR"
 
 usage() {
   cat <<USAGE
@@ -11,19 +27,28 @@ Usage: $0 [options]
   -i  interactive mode (Y ask each dir, A process all without asking)
   -p  maximum concurrent processes (default 200)
   -us USER  sqlplus username (default system)
-  -pa PASS  sqlplus password (default manager)
+  -id INSTANCE_ID  unique instance identifier (auto-generated)
+  -isolation MODE  isolation mode (workdir/global) (default workdir)
   -h  show this help
+
+Isolation modes:
+  workdir - Each working directory is completely isolated
+  global  - All instances share locks regardless of working directory
 USAGE
 }
 
+# Default values
 cpu_limit=85
 mem_limit=80
 root="./"
 interactive="Y"
 max_proc=200
 sql_user="system"
-sql_pass="manager"
+sql_pass=""
+custom_instance_id=""
+isolation_mode="workdir"
 
+# Parse arguments
 while [ $# -gt 0 ]; do
   case "$1" in
     -c) cpu_limit=$2; shift 2;;
@@ -32,133 +57,355 @@ while [ $# -gt 0 ]; do
     -i) interactive=$2; shift 2;;
     -p) max_proc=$2; shift 2;;
     -us) sql_user=$2; shift 2;;
-    -pa) sql_pass=$2; shift 2;;
+    -id) custom_instance_id=$2; shift 2;;
+    -isolation) isolation_mode=$2; shift 2;;
     -h) usage; exit 0;;
     *) usage; exit 1;;
   esac
 done
 
-# disable prompts when running without a terminal (e.g. via nohup)
-if [ ! -t 0 ] && [ "$interactive" = "Y" ]; then
-  interactive="A"
+# Validate isolation mode
+if [ "$isolation_mode" != "workdir" ] && [ "$isolation_mode" != "global" ]; then
+    echo "Error: Invalid isolation mode. Use 'workdir' or 'global'" >&2
+    exit 1
 fi
 
-# internal counters
-completed=0
-started=0
-progress_file=$(mktemp)
-started_file=$(mktemp)
-results="$(date +%Y%m%d_%H%M)_$$.result.csv"
+# Use custom instance ID if provided
+if [ -n "$custom_instance_id" ]; then
+    readonly FINAL_INSTANCE_ID="$custom_instance_id"
+else
+    readonly FINAL_INSTANCE_ID="$INSTANCE_ID"
+fi
 
-echo "0" > "$progress_file"
-echo "0" > "$started_file"
-echo "directory,file,start,end,duration" > "$results"
+# Adjust paths based on isolation mode
+if [ "$isolation_mode" = "global" ]; then
+    readonly FINAL_LOCK_DIR="/tmp/.parallel_locks_global"
+    readonly FINAL_LOG_DIR="${WORK_DIR}/.parallel_logs"
+    readonly FINAL_GLOBAL_LOCK="/tmp/.parallel_locks_global/global.lock"
+    mkdir -p "$FINAL_LOCK_DIR"
+else
+    readonly FINAL_LOCK_DIR="$LOCK_DIR"
+    readonly FINAL_LOG_DIR="$LOG_DIR"
+    readonly FINAL_GLOBAL_LOCK="$GLOBAL_LOCK"
+fi
+
+# Instance-specific files
+readonly results="${FINAL_LOG_DIR}/$(date +%Y%m%d_%H%M)_${FINAL_INSTANCE_ID}.result.csv"
+readonly error_log="${FINAL_LOG_DIR}/$(date +%Y%m%d_%H%M)_${FINAL_INSTANCE_ID}.error.log"
+readonly progress_file="${FINAL_LOCK_DIR}/progress_${FINAL_INSTANCE_ID}"
+readonly started_file="${FINAL_LOCK_DIR}/started_${FINAL_INSTANCE_ID}"
+readonly error_file="${FINAL_LOCK_DIR}/errors_${FINAL_INSTANCE_ID}"
+readonly final_pid_file="${FINAL_LOCK_DIR}/${SCRIPT_NAME}.${FINAL_INSTANCE_ID}.pid"
+
+# Write PID file for instance tracking
+echo $$ > "$final_pid_file"
+
+check_running_instances() {
+    local count=0
+    echo "=== Running Instances ==="
+    echo "Isolation mode: $isolation_mode"
+    echo "Work directory: $WORK_DIR"
+    echo "Lock directory: $FINAL_LOCK_DIR"
+    echo "Checking pattern: ${FINAL_LOCK_DIR}/${SCRIPT_NAME}.*.pid"
+    for pid_file in "${FINAL_LOCK_DIR}"/${SCRIPT_NAME}.*.pid; do
+        [ -f "$pid_file" ] || continue
+        local pid instance_id workdir
+        pid=$(cat "$pid_file" 2>/dev/null || echo "")
+        instance_id=$(basename "$pid_file" .pid | sed "s/${SCRIPT_NAME}.//")
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            count=$((count + 1))
+            workdir=$(readlink -f "/proc/$pid/cwd" 2>/dev/null || echo "unknown")
+            printf "  Instance: %s (PID: %s, WorkDir: %s)\n" "$instance_id" "$pid" "$workdir"
+        else
+            rm -f "$pid_file"
+        fi
+    done
+    echo "Total active instances: $count"
+    echo "========================="
+    return $count
+}
+
+is_file_being_processed() {
+    local file="$1"
+    local abs_file_path
+    abs_file_path="$(readlink -f "$file")"
+    for lock_file in "${FINAL_LOCK_DIR}"/file_*.lock; do
+        [ -f "$lock_file" ] || continue
+        local lock_content
+        lock_content="$(cat "$lock_file" 2>/dev/null || echo "")"
+        if [ -n "$lock_content" ]; then
+            local lock_file_path lock_pid
+            lock_file_path="$(echo "$lock_content" | cut -d: -f2)"
+            lock_pid="$(echo "$lock_content" | cut -d: -f3)"
+            if [ "$abs_file_path" = "$lock_file_path" ]; then
+                if kill -0 "$lock_pid" 2>/dev/null; then
+                    return 0
+                else
+                    rm -f "$lock_file"
+                fi
+            fi
+        fi
+    done
+    return 1
+}
+
+mark_file_processing() {
+    local file="$1"
+    local abs_file_path="$(readlink -f "$file")"
+    local base_name="$(basename "$file")"
+    local file_lock="${FINAL_LOCK_DIR}/file_${FINAL_INSTANCE_ID}_${base_name}_$$.lock"
+    echo "${FINAL_INSTANCE_ID}:${abs_file_path}:$$" > "$file_lock"
+}
+
+unmark_file_processing() {
+    local file="$1"
+    local base_name="$(basename "$file")"
+    local file_lock="${FINAL_LOCK_DIR}/file_${FINAL_INSTANCE_ID}_${base_name}_$$.lock"
+    rm -f "$file_lock"
+}
+
+get_total_script_processes() {
+    local total=0
+    for pid_file in "${FINAL_LOCK_DIR}"/${SCRIPT_NAME}.*.pid; do
+        [ -f "$pid_file" ] || continue
+        local pid
+        pid=$(cat "$pid_file" 2>/dev/null || echo "")
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            local children
+            children=$(pgrep -P "$pid" 2>/dev/null | wc -l)
+            total=$((total + children))
+        fi
+    done
+    echo "$total"
+}
+
+get_workdir_script_processes() {
+    local total=0
+    for pid_file in "${FINAL_LOCK_DIR}"/${SCRIPT_NAME}.*.pid; do
+        [ -f "$pid_file" ] || continue
+        local pid
+        pid=$(cat "$pid_file" 2>/dev/null || echo "")
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            local proc_workdir
+            proc_workdir=$(readlink -f "/proc/$pid/cwd" 2>/dev/null || echo "")
+            if [ "$proc_workdir" = "$WORK_DIR" ]; then
+                local children
+                children=$(pgrep -P "$pid" 2>/dev/null | wc -l)
+                total=$((total + children))
+            fi
+        fi
+    done
+    echo "$total"
+}
 
 get_cpu_usage() {
-  awk '/^cpu /{idle=$5; tot=$2+$3+$4+$5+$6+$7+$8+$9+$10; print int(100 - idle*100/tot)}' /proc/stat
+    awk '/^cpu /{idle=$5; tot=$2+$3+$4+$5+$6+$7+$8+$9+$10; print int(100 - idle*100/tot)}' /proc/stat 2>/dev/null || echo "0"
 }
 
 get_mem_usage() {
-  awk '/MemTotal/{t=$2}/MemAvailable/{a=$2}END{print int((t-a)/t*100)}' /proc/meminfo
-}
-
-get_disk_usage() {
-  df -P "$root" | awk 'NR==2{print $5}'
-}
-
-get_net_stats() {
-  awk 'NR>2{rx+=$2;tx+=$10}END{print rx,tx}' /proc/net/dev
+    awk '/MemTotal/{t=$2}/MemAvailable/{a=$2}END{if(t>0) print int((t-a)/t*100); else print 0}' /proc/meminfo 2>/dev/null || echo "0"
 }
 
 progress_monitor() {
-  read rx0 tx0 < <(get_net_stats)
-  total=$(find "$root" -maxdepth 2 -type f \( -name '*-sh-N' -o -name '*-sql-N' \) | wc -l)
-  while true; do
-    sleep 10
-    completed=$(cat "$progress_file")
-    forked=$(cat "$started_file")
-    cpu=$(get_cpu_usage)
-    mem=$(get_mem_usage)
-    disk=$(get_disk_usage)
-    running=$(jobs -r | wc -l)
-    running=$(( running > 0 ? running-1 : 0 ))
-    read rx1 tx1 < <(get_net_stats)
-    rx=$((rx1-rx0))
-    tx=$((tx1-tx0))
-    rx0=$rx1; tx0=$tx1
-    if [ "$total" -gt 0 ]; then
-      progress=$(( completed * 100 / total ))
-    else
-      progress=100
-    fi
-    echo "Progress: $completed/$total (${progress}%) CPU:${cpu}% MEM:${mem}% DISK:${disk} NET:${rx}/${tx} RUN:${running} FORK:${forked}"
-  done
+    echo "Starting progress monitor for instance: $FINAL_INSTANCE_ID"
+    echo "Work directory: $WORK_DIR"
+    echo "Isolation mode: $isolation_mode"
+    local total
+    total=$(find "$root" -maxdepth 2 -type f \( -name '*-sh-N' -o -name '*-sql-N' \) 2>/dev/null | wc -l)
+    while true; do
+        sleep 10
+        local completed forked errors cpu mem running workdir_procs total_procs
+        completed=$(cat "$progress_file" 2>/dev/null || echo "0")
+        forked=$(cat "$started_file" 2>/dev/null || echo "0")
+        errors=$(cat "$error_file" 2>/dev/null || echo "0")
+        cpu=$(get_cpu_usage)
+        mem=$(get_mem_usage)
+        running=$(jobs -r 2>/dev/null | wc -l)
+        running=$(( running > 0 ? running-1 : 0 ))
+        if [ "$isolation_mode" = "workdir" ]; then
+            workdir_procs=$(get_workdir_script_processes)
+            printf "[%s] Progress: %d/%d (%d%%) CPU:%d%% MEM:%d%% Local:%d WorkDir:%d ERR:%d\n" \
+                   "$FINAL_INSTANCE_ID" "$completed" "$total" \
+                   "$([ "$total" -gt 0 ] && echo $(( completed * 100 / total )) || echo "100")" \
+                   "$cpu" "$mem" "$running" "$workdir_procs" "$errors"
+        else
+            total_procs=$(get_total_script_processes)
+            printf "[%s] Progress: %d/%d (%d%%) CPU:%d%% MEM:%d%% Local:%d Global:%d ERR:%d\n" \
+                   "$FINAL_INSTANCE_ID" "$completed" "$total" \
+                   "$([ "$total" -gt 0 ] && echo $(( completed * 100 / total )) || echo "100")" \
+                   "$cpu" "$mem" "$running" "$total_procs" "$errors"
+        fi
+    done
 }
 
 execute_file() {
-  f="$1"
-  start=$(date +%s)
-  echo "[start] $f"
-  if [[ "$f" == *-sql-* ]]; then
-    sqlplus "$sql_user/$sql_pass" @"$f"
-  else
-    sh "$f"
-  fi
-  end=$(date +%s)
-  dur=$((end-start))
-  new="${f%?}Y"
-  mv "$f" "$new"
-  echo "[done] $f (${dur}s)"
-  echo "$(dirname "$f"),$(basename "$f"),$(date -d @$start +%F\ %T),$(date -d @$end +%F\ %T),$dur" >> "$results"
-  completed=$((completed+1))
-  echo "$completed" > "$progress_file"
+    local f="$1"
+    if is_file_being_processed "$f"; then
+        echo "[skip] $f (being processed by another instance)"
+        return 0
+    fi
+    mark_file_processing "$f"
+    local start end dur status=SUCCESS new
+    start=$(date +%s)
+    echo "[start] $f (instance: $FINAL_INSTANCE_ID, workdir: $WORK_DIR)" | tee -a "$error_log"
+    if [[ "$f" == *-sql-* ]]; then
+        if ! sqlplus -S "$sql_user/$sql_pass" @"$f" 2>>"$error_log"; then
+            status=FAILED
+            echo "[error] SQL execution failed for $f" | tee -a "$error_log"
+            local errors
+            errors=$(cat "$error_file" 2>/dev/null || echo "0")
+            echo $((errors + 1)) > "$error_file"
+        fi
+    else
+        if ! bash "$f" 2>>"$error_log"; then
+            status=FAILED
+            echo "[error] Shell execution failed for $f" | tee -a "$error_log"
+            local errors
+            errors=$(cat "$error_file" 2>/dev/null || echo "0")
+            echo $((errors + 1)) > "$error_file"
+        fi
+    fi
+    end=$(date +%s)
+    dur=$((end-start))
+    (
+        flock -x 200
+        new="${f%?}Y"
+        if [ -f "$f" ] && ! mv "$f" "$new" 2>>"$error_log"; then
+            echo "[warning] Could not rename $f to $new" | tee -a "$error_log"
+        fi
+    ) 200>"$FINAL_GLOBAL_LOCK"
+    echo "[done] $f (${dur}s) - $status (instance: $FINAL_INSTANCE_ID)" | tee -a "$error_log"
+    (
+        flock -x 200
+        echo "$(dirname "$f"),$(basename "$f"),$(date -d @$start +%F\ %T),$(date -d @$end +%F\ %T),$dur,$status,$FINAL_INSTANCE_ID,$WORK_DIR" >> "$results"
+        local completed
+        completed=$(cat "$progress_file" 2>/dev/null || echo "0")
+        echo $((completed + 1)) > "$progress_file"
+    ) 200>>"${results}.lock"
+    unmark_file_processing "$f"
 }
+
+cleanup() {
+    echo "Cleaning up instance: $FINAL_INSTANCE_ID (workdir: $WORK_DIR)"
+    if [ -n "${mon_pid:-}" ]; then
+        kill "$mon_pid" 2>/dev/null || true
+    fi
+    jobs -p | xargs -r kill 2>/dev/null || true
+    wait 2>/dev/null || true
+    rm -f "$progress_file" "$started_file" "$error_file" "${results}.lock"
+    rm -f "${FINAL_LOCK_DIR}"/file_${FINAL_INSTANCE_ID}_*.lock
+    rm -f "$final_pid_file"
+    if [ -f "$results" ]; then
+        local total_completed total_errors
+        total_completed=$(wc -l < "$results" 2>/dev/null || echo "1")
+        total_completed=$((total_completed - 1))
+        total_errors=$(grep -c "FAILED" "$results" 2>/dev/null || echo "0")
+        printf '\n=== INSTANCE %s SUMMARY ===\n' "$FINAL_INSTANCE_ID"
+        printf 'Work directory: %s\n' "$WORK_DIR"
+        printf 'Isolation mode: %s\n' "$isolation_mode"
+        printf 'Total completed: %d\n' "$total_completed"
+        printf 'Total errors: %d\n' "$total_errors"
+        printf 'Results: %s\n' "$results"
+        printf 'Error log: %s\n' "$error_log"
+    fi
+}
+
+validate_inputs() {
+    if [[ ! "$cpu_limit" =~ ^[0-9]+$ ]] || [ "$cpu_limit" -lt 1 ] || [ "$cpu_limit" -gt 100 ]; then
+        echo "Error: CPU limit must be 1-100" >&2
+        exit 1
+    fi
+    if [[ ! "$mem_limit" =~ ^[0-9]+$ ]] || [ "$mem_limit" -lt 1 ] || [ "$mem_limit" -gt 100 ]; then
+        echo "Error: Memory limit must be 1-100" >&2
+        exit 1
+    fi
+    if [ ! -d "$root" ]; then
+        echo "Error: Directory '$root' does not exist" >&2
+        exit 1
+    fi
+    if [[ ! "$max_proc" =~ ^[0-9]+$ ]] || [ "$max_proc" -lt 1 ]; then
+        echo "Error: Max processes must be a positive integer" >&2
+        exit 1
+    fi
+}
+
+get_password() {
+    if [ -n "${SQL_PASSWORD:-}" ]; then
+        sql_pass="$SQL_PASSWORD"
+    elif [ -f "${HOME}/.sqlpass" ]; then
+        sql_pass="$(cat "${HOME}/.sqlpass")"
+    else
+        echo -n "Enter SQL password for user '$sql_user': "
+        read -s sql_pass
+        echo
+    fi
+    if [ -z "$sql_pass" ]; then
+        echo "Error: Password cannot be empty" >&2
+        exit 1
+    fi
+}
+
+validate_inputs
+get_password
+
+echo "0" > "$progress_file"
+echo "0" > "$started_file"
+echo "0" > "$error_file"
+echo "directory,file,start,end,duration,status,instance,workdir" > "$results"
+
+if [ ! -t 0 ] && [ "$interactive" = "Y" ]; then
+    interactive="A"
+fi
+
+trap cleanup EXIT INT TERM
+
+check_running_instances
 
 progress_monitor &
 mon_pid=$!
 
-cleanup() {
-  kill $mon_pid 2>/dev/null
-  kill $(jobs -p) 2>/dev/null
-  wait $mon_pid 2>/dev/null
-  rm -f "$progress_file" "$started_file"
-}
-
-trap cleanup EXIT INT TERM
-
 for dir in $(find "$root" -maxdepth 1 -type d -regex '.*/[a-z]' | sort); do
-  if [ "$interactive" = "Y" ]; then
-    read -p "Process directory $(basename "$dir")? [Y/N/A] " ans
-    case $ans in
-      Y|y) ;;
-      N|n) continue ;;
-      A|a) interactive="A" ;;
-      *) ;;
-    esac
-  fi
-  files=$(find "$dir" -maxdepth 1 -type f \( -name '*-sh-*' -o -name '*-sql-*' \) | sort)
-  for f in $files; do
-    [[ "$f" == *-Y ]] && continue
-    while true; do
-      cpu=$(get_cpu_usage)
-      mem=$(get_mem_usage)
-      running=$(jobs -r | wc -l)
-      running=$(( running > 0 ? running-1 : 0 ))
-      if [ "$cpu" -lt "$cpu_limit" ] && \
-         [ "$mem" -lt "$mem_limit" ] && \
-         [ "$running" -lt "$max_proc" ]; then
-        break
-      fi
-      sleep 1
-    done
-    started=$((started+1))
-    echo "$started" > "$started_file"
-    execute_file "$f" &
-  done
-  wait
+    if [ "$interactive" = "Y" ]; then
+        read -p "Process directory $(basename "$dir")? [Y/N/A] " ans
+        case $ans in
+            Y|y) ;;
+            N|n) continue ;;
+            A|a) interactive="A" ;;
+            *) continue ;;
+        esac
+    fi
+    while IFS= read -r -d '' f; do
+        [[ "$f" == *-Y ]] && continue
+        if is_file_being_processed "$f"; then
+            echo "[skip] $(basename "$f") (locked by another instance)"
+            continue
+        fi
+        while true; do
+            local cpu mem running limit_procs
+            cpu=$(get_cpu_usage)
+            mem=$(get_mem_usage)
+            running=$(jobs -r 2>/dev/null | wc -l)
+            running=$(( running > 0 ? running-1 : 0 ))
+            if [ "$isolation_mode" = "workdir" ]; then
+                limit_procs=$(get_workdir_script_processes)
+            else
+                limit_procs=$(get_total_script_processes)
+            fi
+            if [ "$cpu" -lt "$cpu_limit" ] && \
+               [ "$mem" -lt "$mem_limit" ] && \
+               [ "$running" -lt "$max_proc" ] && \
+               [ "$limit_procs" -lt $((max_proc * 2)) ]; then
+                break
+            fi
+            sleep 1
+        done
+        local started
+        started=$(cat "$started_file" 2>/dev/null || echo "0")
+        echo $((started + 1)) > "$started_file"
+        execute_file "$f" &
+    done < <(find "$dir" -maxdepth 1 -type f \( -name '*-sh-*' -o -name '*-sql-*' \) -print0 2>/dev/null | sort -z)
+    wait
 done
 
 wait
-kill "$mon_pid" 2>/dev/null
-
-printf '\nResults written to %s\n' "$results"
+echo "Instance $FINAL_INSTANCE_ID completed (workdir: $WORK_DIR)."

--- a/oparal.sh
+++ b/oparal.sh
@@ -26,6 +26,7 @@ Usage: $0 [options]
   -d  root directory containing a-z subdirectories (default ./)
   -i  interactive mode (Y ask each dir, A process all without asking)
   -p  maximum concurrent processes (default 200)
+  -op N  number of slave processes to run in parallel (alias for -p)
   -us USER  sqlplus username (default system)
   -pa PASS  sqlplus password (default manager)
   -id INSTANCE_ID  unique instance identifier (auto-generated)
@@ -51,6 +52,7 @@ while [ $# -gt 0 ]; do
     -d) root_dir=$2; shift 2;;
     -i) interactive_mode=$2; shift 2;;
     -p) max_processes=$2; shift 2;;
+    -op) max_processes=$2; shift 2;;
     -us) sql_user=$2; shift 2;;
     -pa) sql_pass=$2; shift 2;;
     -id) custom_instance_id=$2; shift 2;;

--- a/oparal.sh
+++ b/oparal.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Execute shell and SQL files in alphabetical directories with simple CPU/memory
+# based parallelism. Only bash and awk are used.
+
+usage() {
+  cat <<USAGE
+Usage: $0 [options]
+  -c  CPU usage threshold percent (default 85)
+  -m  memory usage threshold percent (default 80)
+  -d  root directory containing a-z subdirectories (default ./)
+  -i  interactive mode (Y ask each dir, A process all without asking)
+  -p  maximum concurrent processes (default 200)
+  -us USER  sqlplus username (default system)
+  -pa PASS  sqlplus password (default manager)
+  -h  show this help
+USAGE
+}
+
+cpu_limit=85
+mem_limit=80
+root="./"
+interactive="Y"
+max_proc=200
+sql_user="system"
+sql_pass="manager"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -c) cpu_limit=$2; shift 2;;
+    -m) mem_limit=$2; shift 2;;
+    -d) root=$2; shift 2;;
+    -i) interactive=$2; shift 2;;
+    -p) max_proc=$2; shift 2;;
+    -us) sql_user=$2; shift 2;;
+    -pa) sql_pass=$2; shift 2;;
+    -h) usage; exit 0;;
+    *) usage; exit 1;;
+  esac
+done
+
+# disable prompts when running without a terminal (e.g. via nohup)
+if [ ! -t 0 ] && [ "$interactive" = "Y" ]; then
+  interactive="A"
+fi
+
+# internal counters
+completed=0
+progress_file=$(mktemp)
+results="$(date +%Y%m%d_%H%M).result.csv"
+
+echo "0" > "$progress_file"
+echo "directory,file,start,end,duration" > "$results"
+
+get_cpu_usage() {
+  awk '/^cpu /{idle=$5; tot=$2+$3+$4+$5+$6+$7+$8+$9+$10; print int(100 - idle*100/tot)}' /proc/stat
+}
+
+get_mem_usage() {
+  awk '/MemTotal/{t=$2}/MemAvailable/{a=$2}END{print int((t-a)/t*100)}' /proc/meminfo
+}
+
+get_disk_usage() {
+  df -P "$root" | awk 'NR==2{print $5}'
+}
+
+get_net_stats() {
+  awk 'NR>2{rx+=$2;tx+=$10}END{print rx,tx}' /proc/net/dev
+}
+
+progress_monitor() {
+  read rx0 tx0 < <(get_net_stats)
+  total=$(find "$root" -maxdepth 2 -type f \( -name '*-sh-N' -o -name '*-sql-N' \) | wc -l)
+  while true; do
+    sleep 10
+    completed=$(cat "$progress_file")
+    cpu=$(get_cpu_usage)
+    mem=$(get_mem_usage)
+    disk=$(get_disk_usage)
+    running=$(jobs -r | wc -l)
+    running=$(( running > 0 ? running-1 : 0 ))
+    read rx1 tx1 < <(get_net_stats)
+    rx=$((rx1-rx0))
+    tx=$((tx1-tx0))
+    rx0=$rx1; tx0=$tx1
+    if [ "$total" -gt 0 ]; then
+      progress=$(( completed * 100 / total ))
+    else
+      progress=100
+    fi
+    echo "Progress: $completed/$total (${progress}%) CPU:${cpu}% MEM:${mem}% DISK:${disk} NET:${rx}/${tx} RUN:${running}"
+  done
+}
+
+execute_file() {
+  f="$1"
+  start=$(date +%s)
+  echo "[start] $f"
+  if [[ "$f" == *-sql-* ]]; then
+    sqlplus "$sql_user/$sql_pass" @"$f"
+  else
+    sh "$f"
+  fi
+  end=$(date +%s)
+  dur=$((end-start))
+  new="${f%?}Y"
+  mv "$f" "$new"
+  echo "[done] $f (${dur}s)"
+  echo "$(dirname "$f"),$(basename "$f"),$(date -d @$start +%F\ %T),$(date -d @$end +%F\ %T),$dur" >> "$results"
+  completed=$((completed+1))
+  echo "$completed" > "$progress_file"
+}
+
+progress_monitor &
+mon_pid=$!
+
+cleanup() {
+  kill $mon_pid 2>/dev/null
+  kill $(jobs -p) 2>/dev/null
+  wait $mon_pid 2>/dev/null
+  rm -f "$progress_file"
+}
+
+trap cleanup EXIT INT TERM
+
+for dir in $(find "$root" -maxdepth 1 -type d -regex '.*/[a-z]' | sort); do
+  if [ "$interactive" = "Y" ]; then
+    read -p "Process directory $(basename "$dir")? [Y/N/A] " ans
+    case $ans in
+      Y|y) ;;
+      N|n) continue ;;
+      A|a) interactive="A" ;;
+      *) ;;
+    esac
+  fi
+  files=$(find "$dir" -maxdepth 1 -type f \( -name '*-sh-*' -o -name '*-sql-*' \) | sort)
+  for f in $files; do
+    [[ "$f" == *-Y ]] && continue
+    while true; do
+      cpu=$(get_cpu_usage)
+      mem=$(get_mem_usage)
+      running=$(jobs -r | wc -l)
+      running=$(( running > 0 ? running-1 : 0 ))
+      if [ "$cpu" -lt "$cpu_limit" ] && \
+         [ "$mem" -lt "$mem_limit" ] && \
+         [ "$running" -lt "$max_proc" ]; then
+        break
+      fi
+      sleep 1
+    done
+    execute_file "$f" &
+  done
+  wait
+done
+
+wait
+kill $mon_pid
+
+printf '\nResults written to %s\n' "$results"

--- a/oparal.sh
+++ b/oparal.sh
@@ -159,6 +159,6 @@ for dir in $(find "$root" -maxdepth 1 -type d -regex '.*/[a-z]' | sort); do
 done
 
 wait
-kill $mon_pid
+kill "$mon_pid" 2>/dev/null
 
 printf '\nResults written to %s\n' "$results"


### PR DESCRIPTION
## Summary
- ignore interactive prompts when stdin isn't a terminal so nohup works
- document automatic noninteractive mode in README

## Testing
- `./oparal.sh -h | head -n 10`
- `bash -n oparal.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840e2d4a644832fa5f0d1f055baf5ca